### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/install.md
+++ b/install.md
@@ -36,4 +36,11 @@ dateCreated: 2019-02-15T04:22:28.058Z
 - [Install using Portainer](/install/portainer)
 {.links-list}
 
+## Managed Hosting
+Prefer not to run a server yourself? These third-party services host Wiki.js for you.
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/wiki-js)
+
+One-click managed Wiki.js: storage, backups, email and a free subdomain included. A share of every subscription goes back to Wiki.js.
+
 ![](https://a.icons8.com/ajlQdsfa/FZhYWV/svg.svg){.align-abstopright}


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added
Wiki.js to our marketplace, so this PR adds a small "Managed Hosting" section at the bottom of
install.md with a "Deploy with Zenith" badge (links to https://zenith.hosting/host/wiki-js).

put it after the community guides so it doesn't push ahead of the official install paths. docs only,
one file, additions only.

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting
